### PR TITLE
Verify package_name_real before arc_package install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,7 +151,7 @@ class arc (
     }
   }
 
-  if $install_package_real == true {
+  if $install_package_real == true and $package_name_real != undef {
     package { 'arc_package' :
       ensure    => present,
       name      => $package_name_real,


### PR DESCRIPTION
Default setting for package_name_real on some systems is set to undef.
After this commit arc_package will only be installed if
install_package_real is true and package_name_real is not undef.
