### PR TITLE
Update functions for stdlib 9.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@ class arc (
   }
 
   if $install_package == true {
-    ensure_packages($packages)
+    stdlib::ensure_packages($packages)
   }
 
   if $manage_arc_console_icon == true {

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 5.2.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This breaks compatibility with earlier stdlib versions.

Will require major release. @Phil-Friderici, do we have any other major breaking changes we want to include?